### PR TITLE
Calcula número de infectados ativos e recuperados inicial

### DIFF
--- a/src/configs/config.yaml
+++ b/src/configs/config.yaml
@@ -26,11 +26,13 @@ br:
         cities_population: https://docs.google.com/spreadsheets/d/1k8mXuUggBuBEghHhhLrLtA-5wa4JsAc-D35S5bNlf24
         health_infrastructure: https://docs.google.com/spreadsheets/d/1JD9GREVkU_doNqQQvvA_NC18HhoulrxcJLTqxd07508
     cases:
-        url: https://brasil.io/api/dataset/covid19/caso/data?is_last=True
+        url: https://data.brasil.io/dataset/covid19/caso_full.csv.gz
         rename:
-            city_ibge_code: city_id
-            date: last_updated
-            confirmed: number_cases
+            city_ibge_code: 'city_id'
+            date: 'last_updated'
+            last_available_deaths: 'deaths'
+            new_confirmed: 'number_cases'
+            recovered: 'recovered'
         drop: [
             'city',
             'confirmed_per_100k_inhabitants',

--- a/src/loader.py
+++ b/src/loader.py
@@ -54,8 +54,7 @@ def _read_cases_data(country, config):
         cases_params = config['br']['cases']
         df = df.rename(columns=cases_params['rename'])
 
-        infectious_period = config['br']['seir_parameters']['mild_duration'] + \
-                            config['br']['seir_parameters']['severe_duration'] + \
+        infectious_period = config['br']['seir_parameters']['severe_duration'] + \
                             config['br']['seir_parameters']['critical_duration']
         
         df['last_updated'] = pd.to_datetime(df['last_updated'])

--- a/src/loader.py
+++ b/src/loader.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import numpy as np
 import requests
 import streamlit as st
+import datetime
 
 def _download_from_drive(url):
 
@@ -46,12 +48,27 @@ def _read_cities_data(country, config):
 def _read_cases_data(country, config):
 
     if country == 'br':
-        cases_params = config[country]['cases']
-        result = requests.get(cases_params['url']).json()['results']
-        df = pd.DataFrame(result)
+        df = pd.read_csv(config[country]['cases']['url'])
         df = df.query('place_type == "city"').dropna(subset=['city_ibge_code'])
+
+        cases_params = config['br']['cases']
         df = df.rename(columns=cases_params['rename'])
-        df = df.drop(cases_params['drop'], 1)
+
+        infectious_period = config['br']['seir_parameters']['mild_duration'] + \
+                            config['br']['seir_parameters']['severe_duration'] + \
+                            config['br']['seir_parameters']['critical_duration']
+        
+        df['last_updated'] = pd.to_datetime(df['last_updated'])
+        first_day = df['last_updated'].max() - datetime.timedelta(infectious_period)
+
+        df = df.merge(df[df['last_updated'] >= first_day].groupby('city_id')['number_cases'].sum(), 
+                    on='city_id', suffixes=('_x', ''))
+
+        df['recovered'] = df['last_available_confirmed'] - df['number_cases'] - df['deaths']
+        # Ajustando casos que recuperados < 0: provável remoção de mortos no acumulado de infetados
+        df['recovered'] = np.where(df['recovered'] < 0, df['last_available_confirmed'] - df['number_cases'], df['recovered'])
+
+        df = df[df['is_last'] == True][cases_params['rename'].values()]
         df['city_id'] = df['city_id'].astype(int)
 
     return df

--- a/src/model_description.py
+++ b/src/model_description.py
@@ -235,7 +235,8 @@ def main():
         de início da simulação. Assim, se $I^t$ é o número de novos casos reportados em $t$, o número de casos ativos é dado por
         $I(0) = \sum_{t=t_i - \delta T}^{t_i} I^t$.
 
-        Considerando $\delta T$ como a soma do tempo de progressão dos casos leve, severo e crítico.
+        Considerando $\delta T$ como a soma do tempo de progressão somente dos casos severo e crítico pois assumimos subnotificação dos casos leves, 
+        ainda sim podemos estar superestimando os casos ativos por não considerar dentre eles os recuperados durante esse período de progressão.
 
         Esse total é separado pela estimativa do percentual de indivíduos em cada estágio de gravidade da 
         doença: segundo [CDC(2020)](https://www.cdc.gov/mmwr/volumes/69/wr/mm6912e2.htm?s_cid=mm6912e2_w), a quantidade de casos severos 
@@ -275,7 +276,8 @@ def main():
         - **Mortos (D)**: iniciamos esse estado com o total de mortes reportado pelo município com os dados do Brasil.io.
 
         - **Recuperados (R)**: sabendo o acumulado histórico de casos, o número mortes ($D$) e o número de casos ativos ($I(0)$),
-        então $R = \sum_{t=t_0}^{t_i} - I(0) - D$
+        então $R = \sum_{t=t_0}^{t_i} - I(0) - D$. Como é possível o número de ativos estar superestimado, por construção o número 
+        de recuperados estaria subestimado - nos casos em que o cálculo dos recuperados não é consistente (negativo), assumimos $R(0) = 0$.
         
         - **Suscetíveis (S)**: o número de indivíduos suscetíveis inicial é dado pelo restante da polucação do município
         que não se encontra em nenhum dos estados acima.

--- a/src/model_description.py
+++ b/src/model_description.py
@@ -5,6 +5,8 @@ from utils import make_clickable
 def main():
 
     st.header("Simulação de Demanda Hospilatar")
+
+    st.write('v1.1')
     
     st.subheader("Resumo")
 

--- a/src/model_description.py
+++ b/src/model_description.py
@@ -229,14 +229,13 @@ def main():
     st.write(
         """
         - **Infectados (I)**: o total de infectados inicialmente é dado pelo número de casos ativos, $I_0$.
-        A fonte utilizada atualmente reporta somente o número acumulado de casos e mortes. Portanto,
-        é necessário calcular o número de casos ativos. Dado que sabemos o tempo de progressão da doença ($\delta T$), 
-        os casos ativos serão todos os casos reportados entre o intervalo $t_f - \delta T$ e $t_i$, onde $t_i$ é o dia
-        de início da simulação. Assim, se $I_r(t)$ é o número de casos reportados em $t$, o número de casos ativos é
-        $I(0) = \sum_{t=t_i - \delta T}^{t_i} I_r(t)$.
+        A fonte utilizada atualmente reporta o número acumulado e novos casos e mortes por dia. Portanto,
+        é necessário calcular o número de casos ativos. Dado o tempo de progressão da doença ($\delta T$), 
+        os casos ativos serão a soma dos novos casos reportados no intervalo $t_i - \delta T$ e $t_i$, onde $t_i$ é o dia
+        de início da simulação. Assim, se $I^t$ é o número de novos casos reportados em $t$, o número de casos ativos é dado por
+        $I(0) = \sum_{t=t_i - \delta T}^{t_i} I^t$.
 
-        Estamos considerando $\delta T$ como a soma do tempo de progressão dos casos
-        leve, severo e crítico.
+        Considerando $\delta T$ como a soma do tempo de progressão dos casos leve, severo e crítico.
 
         Esse total é separado pela estimativa do percentual de indivíduos em cada estágio de gravidade da 
         doença: segundo [CDC(2020)](https://www.cdc.gov/mmwr/volumes/69/wr/mm6912e2.htm?s_cid=mm6912e2_w), a quantidade de casos severos 
@@ -276,7 +275,7 @@ def main():
         - **Mortos (D)**: iniciamos esse estado com o total de mortes reportado pelo município com os dados do Brasil.io.
 
         - **Recuperados (R)**: sabendo o acumulado histórico de casos, o número mortes ($D$) e o número de casos ativos ($I(0)$),
-        então $R = \sum_{t=t_0}^{t_f} - I(0) - D$
+        então $R = \sum_{t=t_0}^{t_i} - I(0) - D$
         
         - **Suscetíveis (S)**: o número de indivíduos suscetíveis inicial é dado pelo restante da polucação do município
         que não se encontra em nenhum dos estados acima.

--- a/src/model_description.py
+++ b/src/model_description.py
@@ -4,8 +4,6 @@ from utils import make_clickable
 
 def main():
 
-    st.header("EM CONSTRUÇÃO...")
-
     st.header("Simulação de Demanda Hospilatar")
     
     st.subheader("Resumo")
@@ -228,8 +226,16 @@ def main():
 
     st.write(
         """
-        - **Infectados (I)**: o total de infectados inicialmente é dado pelo número de casos reportados do município (ver Fontes). 
-        Este valor pode ser modificado pelo usuário nos controles laterais para a simulação.
+        - **Infectados (I)**: o total de infectados inicialmente é dado pelo número de casos ativos, $I_0$.
+        A fonte utilizada atualmente reporta somente o número acumulado de casos e mortes. Portanto,
+        é necessário calcular o número de casos ativos. Dado que sabemos o tempo de progressão da doença ($\delta T$), 
+        os casos ativos serão todos os casos reportados entre o intervalo $t_f - \delta T$ e $t_i$, onde $t_i$ é o dia
+        de início da simulação. Assim, se $I_r(t)$ é o número de casos reportados em $t$, o número de casos ativos é
+        $I(0) = \sum_{t=t_i - \delta T}^{t_i} I_r(t)$.
+
+        Estamos considerando $\delta T$ como a soma do tempo de progressão dos casos
+        leve, severo e crítico.
+
         Esse total é separado pela estimativa do percentual de indivíduos em cada estágio de gravidade da 
         doença: segundo [CDC(2020)](https://www.cdc.gov/mmwr/volumes/69/wr/mm6912e2.htm?s_cid=mm6912e2_w), a quantidade de casos severos 
         ($I_2$) e críticos ($I_3$) é dada por $12\%$ e $2.5\%$ dos total de infectados, respectivamente, 
@@ -265,12 +271,11 @@ def main():
 
     st.write(
         """
-        - **Recuperados (R)**: iniciamos o modelo sem indivíduos recuperados por padrão. 
-        Este valor pode ser modificado pelo usuário nos controles laterais para a simulação.
-
         - **Mortos (D)**: iniciamos esse estado com o total de mortes reportado pelo município com os dados do Brasil.io.
-        Este valor pode ser modificado pelo usuário nos controles laterais para a simulação.
 
+        - **Recuperados (R)**: sabendo o acumulado histórico de casos, o número mortes ($D$) e o número de casos ativos ($I(0)$),
+        então $R = \sum_{t=t_0}^{t_f} - I(0) - D$
+        
         - **Suscetíveis (S)**: o número de indivíduos suscetíveis inicial é dado pelo restante da polucação do município
         que não se encontra em nenhum dos estados acima.
         """

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -42,7 +42,7 @@ def initialize_params(user_input, selected_region):
                      'N': selected_region['population'],
                      'I': int(selected_region['number_cases']),
                      'D': int(selected_region['deaths']),
-                     'R': 0}
+                     'R': int(selected_region['recovered'])}
 
         # INITIAL VALUES FOR BEDS AND VENTILATORS
         user_input['n_beds'] = int(selected_region['number_beds']*0.2)
@@ -89,6 +89,7 @@ def main():
         utils.genInputCustomizationSectionHeader(locality)
 
         user_input['population_params']['I'] = st.number_input('Número de casos confirmados:', 0, None, int(selected_region['number_cases']))
+        user_input['population_params']['R'] = st.number_input('Número de recuperados:', 0, None, int(selected_region['recovered']))
         user_input['population_params']['D'] = st.number_input('Número de mortes:', 0, None, int(selected_region['deaths']))
 
         total_beds = user_input['n_beds']


### PR DESCRIPTION
Closes #50 

- Calcula o número de infectados ativos no último dia
- Estima os recuperados do último dia (`acumulado de infectados - ativos ultimo dia - total mortos`)

**Premissas** : usamos o total de dias de progressão da doença (`mild_period + severe_period + critical_period`) para somar os novos casos diários reportados até hoje como os ativos totais.

**Considerações**: em alguns municípios, o número de recuperados é < 0! 

Nesses casos, assumimos somente `recuperados = infectados acumulados - ativos`, pois o negativo pode ser devido à remoção de mortos do total de infectados

- Possível modificação: se a divulgação de casos for somente graves e críticos, a janela de tempo que devemos considerar é somente `severe_period + critical_period`