### PR TITLE
Consertando seleção de notificação

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ make serve
 
 # Execute o servidor com API local. 
 # Para isso, você terá que subir a API do simulacovid-datasource
-# Use `make server-build-run`
+# 1. Para subir o servidor local: `make server-build-run`
+# 2. Abra outro terminal e rode para subir os dados: `make loader-build-run`
 make serve-local
 ```
 

--- a/src/loader.py
+++ b/src/loader.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import streamlit as st
 import os
 
@@ -13,6 +14,9 @@ def read_data(country, config, refresh_rate):
     print(url)
 
     df = pd.read_csv(url)
+    
+    # convert to datetime
+    df['last_updated'] = df['last_updated'].replace('0', np.nan)
     df[[c for c in df.columns if 'last_updated' in c]] = df[[c for c in df.columns if 'last_updated' in c]].apply(pd.to_datetime)
 
     return  df


### PR DESCRIPTION
Muita coisa aconteceu até aqui rs, mas em resumo:

- Qual o problema? 

1. Não estávamos gerando taxa de notificação para cidades sem casos --> por construção, os recuperados apareciam como NaN nesses casos, o que bugava a simulação
2. Caso a taxa de notificação fosse > 100%, a gente diminuía o número de casos

- **O que foi feito?**
  1. No repo do [datasource](https://github.com/ImpulsoGov/simulacovid-datasource), adicionei a taxa de notificação do estado para cidades sem casos (1) e deixei em 100% quando a taxa era maior i.e. não ajusta os casos (2)
  2. Resolvi com o @JoaoCarabetta como fazer teste do que acontece no app com alguma mudança no [datasource](https://github.com/ImpulsoGov/simulacovid-datasource) (está no README como rodar local).