### PR TITLE
Add rt para simulacao de capacidade

### DIFF
--- a/src/central.py
+++ b/src/central.py
@@ -8,105 +8,91 @@ from simulator import run_evolution
 from simulation import calculate_recovered, filter_options
 import utils
 
+# Dados da projeção de capacidade de leitos
+def dday_city(params, selected_region, config, supply_type="n_beds"):
+
+    params["population_params"] = {
+        "N": selected_region["population"],
+        "I": selected_region["active_cases"],
+        "D": selected_region["deaths"]
+    }
+
+    params["strategy"] = {'isolation': 90, 'lockdown': 90}
+
+    params["n_beds"] = selected_region["number_beds"]
+    params["n_ventilators"] = selected_region["number_ventilators"]
+
+    if np.isnan(selected_region["active_cases"]):
+        params["population_params"]["I"] = 1
+    
+    if np.isnan(selected_region["deaths"]):
+        params["population_params"]["D"] = 0
+    
+    params = calculate_recovered(params, selected_region, params['notification_rate'])
+    _, dday_beds, dday_ventilators = run_evolution(params, config)
+    
+    return dday_beds["best"], dday_beds["worst"]
 
 def main():
 
     # GET DATA
-    config = yaml.load(open("configs/config.yaml", "r"), Loader=yaml.FullLoader)
-    df = loader.read_data(
-        "br", config, endpoint=config["br"]["api"]["endpoints"]["farolcovid"]
-    )
+    config = yaml.load(open('configs/config.yaml', 'r'), Loader = yaml.FullLoader)
+    cities = loader.read_data('br', config, endpoint=config['br']['api']['endpoints']['simulacovid'])
+
+    # # Dados In Loco
+    # inloco_url = yaml.load(open("configs/secrets.yaml", "r"), Loader=yaml.FullLoader)["inloco"]
+    # df_inloco_cities = pd.read_csv(inloco_url["cities"])
+    # df_inloco_states = pd.read_csv(inloco_url["states"])
+
+    # Dados Rt
+    df_rt_cities = loader.read_data("br", config, endpoint="br/cities/rt")
+    df_rt_states = loader.read_data("br", config, endpoint="br/states/rt")
 
     # REGION/CITY USER INPUT
     user_input = dict()
+    indicators = dict()
 
-    level = st.selectbox("Nível", ["Municipal"])  # ["Estadual", "Municipal"])
+    level = st.selectbox('Nível', ["Estadual", "Municipal"])
 
-    # if level == "Estadual":
-    #     user_input['state'] = st.selectbox('Estado', cities['state_name'].unique())
-    #     cities_filtered = filter_options(cities, user_input['state'], 'state_name')
-    #     user_input["place_type"] = "state"
+    if level == "Estadual":
+        user_input['state'] = st.selectbox('Estado', cities['state_name'].unique())
+        cities_filtered = filter_options(cities, user_input['state'], 'state_name')
 
     if level == "Municipal":
-        user_input["city"] = st.selectbox("Município", df["city_name"].unique())
-        cities_filtered = filter_options(df, user_input["city"], "city_name")
-        user_input["place_type"] = "city_id"
+        user_input['city'] = st.selectbox('Município', cities['city_name'].unique())
+        cities_filtered = filter_options(cities, user_input['city'], 'city_name')
 
-    # selected_region = cities_filtered.sum(numeric_only=True)
+    selected_region = cities_filtered.sum(numeric_only=True)
 
-    st.write(
-        "<b>Nível de Alerta: </b>",
-        cities_filtered["overall_alert"].values[0].upper(),
-        unsafe_allow_html=True,
-    )
+    # GET NOTIFICATION RATE & Rt
+    if len(cities_filtered) > 1: # pega taxa do estado quando +1 municipio selecionado
+            user_input["notification_rate"] = round(cities_filtered['state_notification_rate'].mean(), 4)
+            rt = df_rt_states[df_rt_states["state"] == cities_filtered["state"].unique()[0]]
 
-    st.write(
-        "Subnotificação: {}%".format(
-            100 * round(float(cities_filtered["subnotification_rate"].values[0]), 4)
-        )
-    )
-    st.write(
-        "Taxa de mortalidade: {}%".format(
-            100
-            * round(
-                float(
-                    cities_filtered["subnotification_last_mortality_ratio"].values[0]
-                ),
-                4,
-            )
-        )
-    )
-    st.write(
-        "Ranking da UF: <i>{}º município com maior subnotificação</i>".format(
-            int(cities_filtered["subnotification_rank"].values[0])
-        ),
-        unsafe_allow_html=True,
-    )
+    elif np.isnan(cities_filtered['notification_rate'].values):
+            user_input["notification_rate"] = 1
+            rt = df_rt_cities[df_rt_cities["city_id"] == cities_filtered["city_id"].iloc[0]]
 
-    st.write(
-        "Taxa de contagio (ultimos 10 dias): entre {} e {}  - Classificação: <i>{}</i>".format(
-            cities_filtered["rt_10days_ago_low"].values[0],
-            cities_filtered["rt_10days_ago_high"].values[0],
-            cities_filtered["rt_classification"].values[0],
-        ),
-        unsafe_allow_html=True,
-    )
+    else:
+            user_input["notification_rate"] = round(cities_filtered['notification_rate'], 4)
+            rt = df_rt_cities[df_rt_cities["city_id"] == cities_filtered["city_id"].iloc[0]]
 
-    st.write(
-        "Taxa de contagio (ultimos 17 dias): entre {} e {} - Comparação: <i>{}</i>".format(
-            cities_filtered["rt_17days_ago_low"].values[0],
-            cities_filtered["rt_17days_ago_high"].values[0],
-            cities_filtered["rt_comparision"].values[0],
-        ),
-        unsafe_allow_html=True,
-    )
+    if len(rt) < 1:
+        st.write("Rt: Sua cidade não possui casos suficiente para o cálculo!")
+    else:
+        indicators["rt_high"] = rt.iloc[-1]["Rt_high_95"]
+        indicators["rt_low"] = rt.iloc[-1]["Rt_low_95"]
 
-    st.write(
-        "Distanciamento social (hoje): {}%".format(
-            100 * round(float(cities_filtered["inloco_today_7days_avg"].values[0]), 3)
-        ),
-        unsafe_allow_html=True,
-    )
-    st.write(
-        "Distanciamento social: {}% (ultima semana) - Comparação: <i>{}</i>".format(
-            100
-            * round(float(cities_filtered["inloco_last_week_7days_avg"].values[0]), 3),
-            cities_filtered["inloco_comparision"].values[0],
-        ),
-        unsafe_allow_html=True,
-    )
+        st.write(" ".join(["Rt: entre", str(indicators["rt_low"]), "e" , str(indicators["rt_high"])]))
 
-    st.write(
-        "Capacidade Hospitalar: entre {} e {} dias  - Classificação: <i>{}</i>".format(
-            cities_filtered["dday_beds_best"].values[0],
-            cities_filtered["dday_beds_worst"].values[0],
-            cities_filtered["dday_classification"].values[0],
-        ),
-        unsafe_allow_html=True,
-    )
 
+    # GET DDAY BEDS
+    indicators["dday_beds_best"], indicators["dday_beds_worst"] = dday_city(user_input, selected_region, config, supply_type="n_beds")
+    st.write(" ".join(["Dias para capacidade: entre", str(indicators["dday_beds_worst"]), "e", str(indicators["dday_beds_best"])]))
+
+    # INDICATORS
+    # sources = cities_filtered[[c for c in cities_filtered.columns if (('author' in c) or ('last_updated_' in c))]]
     st.write("Você está aqui!")
-
 
 if __name__ == "__main__":
     main()

--- a/src/central.py
+++ b/src/central.py
@@ -8,91 +8,105 @@ from simulator import run_evolution
 from simulation import calculate_recovered, filter_options
 import utils
 
-# Dados da projeção de capacidade de leitos
-def dday_city(params, selected_region, config, supply_type="n_beds"):
-
-    params["population_params"] = {
-        "N": selected_region["population"],
-        "I": selected_region["active_cases"],
-        "D": selected_region["deaths"]
-    }
-
-    params["strategy"] = {'isolation': 90, 'lockdown': 90}
-
-    params["n_beds"] = selected_region["number_beds"]
-    params["n_ventilators"] = selected_region["number_ventilators"]
-
-    if np.isnan(selected_region["active_cases"]):
-        params["population_params"]["I"] = 1
-    
-    if np.isnan(selected_region["deaths"]):
-        params["population_params"]["D"] = 0
-    
-    params = calculate_recovered(params, selected_region, params['notification_rate'])
-    _, dday_beds, dday_ventilators = run_evolution(params, config)
-    
-    return dday_beds["best"], dday_beds["worst"]
 
 def main():
 
     # GET DATA
-    config = yaml.load(open('configs/config.yaml', 'r'), Loader = yaml.FullLoader)
-    cities = loader.read_data('br', config, endpoint=config['br']['api']['endpoints']['simulacovid'])
-
-    # # Dados In Loco
-    # inloco_url = yaml.load(open("configs/secrets.yaml", "r"), Loader=yaml.FullLoader)["inloco"]
-    # df_inloco_cities = pd.read_csv(inloco_url["cities"])
-    # df_inloco_states = pd.read_csv(inloco_url["states"])
-
-    # Dados Rt
-    df_rt_cities = loader.read_data("br", config, endpoint="br/cities/rt")
-    df_rt_states = loader.read_data("br", config, endpoint="br/states/rt")
+    config = yaml.load(open("configs/config.yaml", "r"), Loader=yaml.FullLoader)
+    df = loader.read_data(
+        "br", config, endpoint=config["br"]["api"]["endpoints"]["farolcovid"]
+    )
 
     # REGION/CITY USER INPUT
     user_input = dict()
-    indicators = dict()
 
-    level = st.selectbox('Nível', ["Estadual", "Municipal"])
+    level = st.selectbox("Nível", ["Municipal"])  # ["Estadual", "Municipal"])
 
-    if level == "Estadual":
-        user_input['state'] = st.selectbox('Estado', cities['state_name'].unique())
-        cities_filtered = filter_options(cities, user_input['state'], 'state_name')
+    # if level == "Estadual":
+    #     user_input['state'] = st.selectbox('Estado', cities['state_name'].unique())
+    #     cities_filtered = filter_options(cities, user_input['state'], 'state_name')
+    #     user_input["place_type"] = "state"
 
     if level == "Municipal":
-        user_input['city'] = st.selectbox('Município', cities['city_name'].unique())
-        cities_filtered = filter_options(cities, user_input['city'], 'city_name')
+        user_input["city"] = st.selectbox("Município", df["city_name"].unique())
+        cities_filtered = filter_options(df, user_input["city"], "city_name")
+        user_input["place_type"] = "city_id"
 
-    selected_region = cities_filtered.sum(numeric_only=True)
+    # selected_region = cities_filtered.sum(numeric_only=True)
 
-    # GET NOTIFICATION RATE & Rt
-    if len(cities_filtered) > 1: # pega taxa do estado quando +1 municipio selecionado
-            user_input["notification_rate"] = round(cities_filtered['state_notification_rate'].mean(), 4)
-            rt = df_rt_states[df_rt_states["state"] == cities_filtered["state"].unique()[0]]
+    st.write(
+        "<b>Nível de Alerta: </b>",
+        cities_filtered["overall_alert"].values[0].upper(),
+        unsafe_allow_html=True,
+    )
 
-    elif np.isnan(cities_filtered['notification_rate'].values):
-            user_input["notification_rate"] = 1
-            rt = df_rt_cities[df_rt_cities["city_id"] == cities_filtered["city_id"].iloc[0]]
+    st.write(
+        "Subnotificação: {}%".format(
+            100 * round(float(cities_filtered["subnotification_rate"].values[0]), 4)
+        )
+    )
+    st.write(
+        "Taxa de mortalidade: {}%".format(
+            100
+            * round(
+                float(
+                    cities_filtered["subnotification_last_mortality_ratio"].values[0]
+                ),
+                4,
+            )
+        )
+    )
+    st.write(
+        "Ranking da UF: <i>{}º município com maior subnotificação</i>".format(
+            int(cities_filtered["subnotification_rank"].values[0])
+        ),
+        unsafe_allow_html=True,
+    )
 
-    else:
-            user_input["notification_rate"] = round(cities_filtered['notification_rate'], 4)
-            rt = df_rt_cities[df_rt_cities["city_id"] == cities_filtered["city_id"].iloc[0]]
+    st.write(
+        "Taxa de contagio (ultimos 10 dias): entre {} e {}  - Classificação: <i>{}</i>".format(
+            cities_filtered["rt_10days_ago_low"].values[0],
+            cities_filtered["rt_10days_ago_high"].values[0],
+            cities_filtered["rt_classification"].values[0],
+        ),
+        unsafe_allow_html=True,
+    )
 
-    if len(rt) < 1:
-        st.write("Rt: Sua cidade não possui casos suficiente para o cálculo!")
-    else:
-        indicators["rt_high"] = rt.iloc[-1]["Rt_high_95"]
-        indicators["rt_low"] = rt.iloc[-1]["Rt_low_95"]
+    st.write(
+        "Taxa de contagio (ultimos 17 dias): entre {} e {} - Comparação: <i>{}</i>".format(
+            cities_filtered["rt_17days_ago_low"].values[0],
+            cities_filtered["rt_17days_ago_high"].values[0],
+            cities_filtered["rt_comparision"].values[0],
+        ),
+        unsafe_allow_html=True,
+    )
 
-        st.write(" ".join(["Rt: entre", str(indicators["rt_low"]), "e" , str(indicators["rt_high"])]))
+    st.write(
+        "Distanciamento social (hoje): {}%".format(
+            100 * round(float(cities_filtered["inloco_today_7days_avg"].values[0]), 3)
+        ),
+        unsafe_allow_html=True,
+    )
+    st.write(
+        "Distanciamento social: {}% (ultima semana) - Comparação: <i>{}</i>".format(
+            100
+            * round(float(cities_filtered["inloco_last_week_7days_avg"].values[0]), 3),
+            cities_filtered["inloco_comparision"].values[0],
+        ),
+        unsafe_allow_html=True,
+    )
 
+    st.write(
+        "Capacidade Hospitalar: entre {} e {} dias  - Classificação: <i>{}</i>".format(
+            cities_filtered["dday_beds_best"].values[0],
+            cities_filtered["dday_beds_worst"].values[0],
+            cities_filtered["dday_classification"].values[0],
+        ),
+        unsafe_allow_html=True,
+    )
 
-    # GET DDAY BEDS
-    indicators["dday_beds_best"], indicators["dday_beds_worst"] = dday_city(user_input, selected_region, config, supply_type="n_beds")
-    st.write(" ".join(["Dias para capacidade: entre", str(indicators["dday_beds_worst"]), "e", str(indicators["dday_beds_best"])]))
-
-    # INDICATORS
-    # sources = cities_filtered[[c for c in cities_filtered.columns if (('author' in c) or ('last_updated_' in c))]]
     st.write("Você está aqui!")
+
 
 if __name__ == "__main__":
     main()

--- a/src/configs/config.yaml
+++ b/src/configs/config.yaml
@@ -27,6 +27,7 @@ br:
         local: http://localhost:7000/
         endpoints:
             simulacovid: "br/cities/simulacovid/main"
+            farolcovid: "br/cities/farolcovid/main"
             rt_cities: "br/cities/rt"
             rt_states: "br/states/rt"
             analysis:

--- a/src/configs/config.yaml
+++ b/src/configs/config.yaml
@@ -27,6 +27,8 @@ br:
         local: http://localhost:7000/
         endpoints:
             simulacovid: "br/cities/simulacovid/main"
+            rt_cities: "br/cities/rt"
+            rt_states: "br/states/rt"
             analysis:
                 cases: "br/cities/cases/full"
                 owid: "world/owid/heatmap"

--- a/src/model/simulator.py
+++ b/src/model/simulator.py
@@ -5,38 +5,86 @@ import yaml
 from scipy.integrate import odeint
 from tqdm import tqdm
 import sys
+
 # sys.path.insert(0,'.')
 # from seir import entrypoint
 from model.seir import entrypoint
+import loader
+import datetime as dt
+
 
 def iterate_simulation(current_state, seir_parameters, phase, initial):
     """
     Iterate over simulation phase, returning evolution and new current state.
     """
-    
+
     res = entrypoint(current_state, seir_parameters, phase, initial)
-    current_state = res.drop('scenario', axis=1).iloc[-1].to_dict() # new initial = last date
-    
+    current_state = (
+        res.drop("scenario", axis=1).iloc[-1].to_dict()
+    )  # new initial = last date
+
     return res, current_state
 
+
 # Get reproduction rate
-def get_r0(scenario_parameters, simulation_params, bound):
-    
+def get_rt(config, place_id, place_type, simulation_params, bound):
+
+    if place_type == "city_id":
+        endpoint = config["br"]["api"]["endpoints"]["rt_cities"]
+    if place_type == "state":
+        endpoint = config["br"]["api"]["endpoints"]["rt_states"]
+
+    rt = loader.read_data("br", config, endpoint=endpoint)
+    # pegando estimacao de 10 dias atras
+    rt = rt[rt["last_updated"] == (rt["last_updated"].max() - dt.timedelta(10))]
+
+    # caso nao tenha rt, usa o r0 de wuhan
+    if place_id not in rt[place_type].values:
+        return get_r0(config["simulator"]["scenarios"], simulation_params, bound)
+
+    cols = {"best": "Rt_low_95", "worst": "Rt_high_95"}
+
     for phase in simulation_params:
-        simulation_params[phase]['R0'] = scenario_parameters[bound][simulation_params[phase]['scenario']]['R0']
+
+        # TODO: mudar para novas flags com o front
+        if simulation_params[phase]["scenario"] == "isolation":  # nothing
+            simulation_params[phase]["R0"] = rt[rt[place_type] == place_id][
+                cols[bound]
+            ].values[0]
+
+        if simulation_params[phase]["scenario"] == "lockdown":  # smaller_rt
+            simulation_params[phase]["R0"] = (
+                rt[rt[place_type] == place_id][cols[bound]].values[0] / 2
+            )
+
+        if simulation_params[phase]["scenario"] == "nothing":  # greater_rt
+            simulation_params[phase]["R0"] = (
+                rt[rt[place_type] == place_id][cols[bound]].values[0] * 2
+            )
 
     return simulation_params
 
-def decide_scenario(user_strategy):
-    
-    if user_strategy['isolation'] < user_strategy['lockdown']:
-        return ['nothing', 'isolation', 'lockdown']
-    elif user_strategy['isolation'] == user_strategy['lockdown']: # lockdown only
-        return ['nothing', 'lockdown', 'lockdown']
-    else:
-        return ['nothing', 'lockdown', 'isolation']
 
-def run_simulation(population_params, strategy_params, default_params):
+def get_r0(scenario_parameters, simulation_params, bound):
+
+    for phase in simulation_params:
+        simulation_params[phase]["R0"] = scenario_parameters[bound][
+            simulation_params[phase]["scenario"]
+        ]["R0"]
+    return simulation_params
+
+
+def decide_scenario(user_strategy):
+
+    if user_strategy["isolation"] < user_strategy["lockdown"]:
+        return ["nothing", "isolation", "lockdown"]
+    elif user_strategy["isolation"] == user_strategy["lockdown"]:  # lockdown only
+        return ["nothing", "lockdown", "lockdown"]
+    else:
+        return ["nothing", "lockdown", "isolation"]
+
+
+def run_simulation(population_params, strategy_params, config, place_id, place_type):
     """
     Run simulation phases and return hospital demand.
     
@@ -60,119 +108,204 @@ def run_simulation(population_params, strategy_params, default_params):
         States evolution over phases
         
     """
-    
-    dfs = {'worst': np.nan, 'best': np.nan}
-    
+
+    dfs = {"worst": np.nan, "best": np.nan}
+
     # Run worst scenario
     for bound in dfs.keys():
-        
+
         # Get ranges with test delay
-        intervals = (min(strategy_params.values()) + default_params['simulator']['scenarios'][bound]['test_delay'],
-                     max(strategy_params.values()) - min(strategy_params.values()),
-                     default_params['simulator']['max_days'] - max(strategy_params.values()))
-        
+        intervals = (
+            min(strategy_params.values())
+            + config["simulator"]["scenarios"][bound]["test_delay"],
+            max(strategy_params.values()) - min(strategy_params.values()),
+            config["simulator"]["max_days"] - max(strategy_params.values()),
+        )
+
         scenarios = decide_scenario(strategy_params)
-        simulation_params = {f'phase{i+1}': {'scenario': scenarios[i], 'n_days': intervals[i]} for i in range(3)}
-    
-        # Get R0s
-        simulation_params = get_r0(default_params['simulator']['scenarios'], simulation_params, bound)
+        simulation_params = {
+            f"phase{i+1}": {"scenario": scenarios[i], "n_days": intervals[i]}
+            for i in range(3)
+        }
+
+        # Get Rts
+        if place_id == "Brasil":
+            simulation_params = get_r0(
+                config["simulator"]["scenarios"], simulation_params, bound
+            )
+        else:
+            simulation_params = get_rt(
+                config, place_id, place_type, simulation_params, bound
+            )
 
         # Iterate over phases
         df_evolution = pd.DataFrame()
-        
+
         for phase in simulation_params:
 
-            if phase == 'phase1':
-                res, current_state = iterate_simulation(population_params, 
-                                                        default_params['br']['seir_parameters'], 
-                                                        simulation_params[phase], initial=True)
-                df_evolution = df_evolution.append(res) # consider 1st day
+            if phase == "phase1":
+                res, current_state = iterate_simulation(
+                    population_params,
+                    config["br"]["seir_parameters"],
+                    simulation_params[phase],
+                    initial=True,
+                )
+                df_evolution = df_evolution.append(res)  # consider 1st day
 
             else:
-                res, current_state = iterate_simulation(current_state, 
-                                                        default_params['br']['seir_parameters'], 
-                                                        simulation_params[phase], initial=False)
+                res, current_state = iterate_simulation(
+                    current_state,
+                    config["br"]["seir_parameters"],
+                    simulation_params[phase],
+                    initial=False,
+                )
                 df_evolution = df_evolution.append(res[1:])
 
-        df_evolution = df_evolution[default_params['simulator']['scenarios'][bound]['test_delay']:]
+        df_evolution = df_evolution[
+            config["simulator"]["scenarios"][bound]["test_delay"] :
+        ]
         df_evolution = df_evolution.reset_index(drop=True)
         df_evolution.index += 1
-        df_evolution.index.name = 'dias'
-        
+        df_evolution.index.name = "dias"
+
         dfs[bound] = df_evolution
-    
+
     return dfs
 
 
-def get_dday(dfs,col,resource_number):
-    
+def get_dday(dfs, col, resource_number):
+
     dday = dict()
-    for case in ['worst', 'best']:
+    for case in ["worst", "best"]:
         df = dfs[case]
-        
+
         if max(df[col]) > resource_number:
             dday[case] = df[df[col] > resource_number].index[0]
         else:
-            dday[case] = -1 # change here!
-    
+            dday[case] = -1  # change here!
+
     return dday
+
 
 import plotly.graph_objects as go
 
+
 def plot_fig(t, cols):
-    
+
     fig = go.Figure()
     for col in t.columns:
-        i_type = col.split('_')[0]
+        i_type = col.split("_")[0]
 
-        if 'best' in col:
-            fig.add_trace(go.Scatter(x=t.index, y=t[col].astype(int), name=cols[i_type]['name'], showlegend=False, fill=None, 
-                                     hovertemplate=None, #'%{y:.0f} no dia %{x}', 
-                                     mode='lines', line=dict(color=cols[i_type]['color'], width=3)))
+        if "best" in col:
+            fig.add_trace(
+                go.Scatter(
+                    x=t.index,
+                    y=t[col].astype(int),
+                    name=cols[i_type]["name"],
+                    showlegend=False,
+                    fill=None,
+                    hovertemplate=None,  #'%{y:.0f} no dia %{x}',
+                    mode="lines",
+                    line=dict(color=cols[i_type]["color"], width=3),
+                )
+            )
 
         else:
-            fig.add_trace(go.Scatter(x=t.index, y=t[col].astype(int), name=cols[i_type]['name'], fill='tonexty',
-                                     hovertemplate=None, #'%{y:.0f} no dia %{x}',
-                                     mode='lines', line=dict(color=cols[i_type]['color'], width=3)))
-    
+            fig.add_trace(
+                go.Scatter(
+                    x=t.index,
+                    y=t[col].astype(int),
+                    name=cols[i_type]["name"],
+                    fill="tonexty",
+                    hovertemplate=None,  #'%{y:.0f} no dia %{x}',
+                    mode="lines",
+                    line=dict(color=cols[i_type]["color"], width=3),
+                )
+            )
+
     for i_type in cols.keys():
-        fig.add_trace(go.Scatter(x=t.index, y=[cols[i_type]['capacity'] for i in t.index], name=cols[i_type]['resource_name'],
-                                showlegend=False, hovertemplate=None, mode='lines',
-                                line=dict(color=cols[i_type]['color'], width=6, dash="dash")))
+        fig.add_trace(
+            go.Scatter(
+                x=t.index,
+                y=[cols[i_type]["capacity"] for i in t.index],
+                name=cols[i_type]["resource_name"],
+                showlegend=False,
+                hovertemplate=None,
+                mode="lines",
+                line=dict(color=cols[i_type]["color"], width=6, dash="dash"),
+            )
+        )
 
-    fig.update_layout(#title="<b>EVOLUÇÃO DIÁRIA DA DEMANDA HOSPITALAR</b>", titlefont=dict(size=24, family='Oswald, sans-serif'), 
-                    paper_bgcolor='rgba(0,0,0,0)', plot_bgcolor='rgba(0,0,0,0)',
-                    legend_orientation="h", legend=dict(x=0, y=-.2, font=dict(size=18, family='Oswald, sans-serif')),
-                    hovermode="x", 
-                    autosize=False, width=1000, height=800)
-    
-    fig.update_xaxes(title="dias", tickfont=dict(size=16, family='Oswald, sans-serif'),
-                    # titletext=dict(xref='paper', x=0),
-                    titlefont=dict(size=18, family='Oswald, sans-serif'), 
-                    showline=True, linewidth=2, linecolor='black', showgrid=False)
+    fig.update_layout(  # title="<b>EVOLUÇÃO DIÁRIA DA DEMANDA HOSPITALAR</b>", titlefont=dict(size=24, family='Oswald, sans-serif'),
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        legend_orientation="h",
+        legend=dict(x=0, y=-0.2, font=dict(size=18, family="Oswald, sans-serif")),
+        hovermode="x",
+        autosize=False,
+        width=1000,
+        height=800,
+    )
 
-    fig.update_yaxes(gridwidth=1, gridcolor='#d7d8d9', tickfont=dict(size=16, family='Oswald, sans-serif'),)
-    
+    fig.update_xaxes(
+        title="dias",
+        tickfont=dict(size=16, family="Oswald, sans-serif"),
+        # titletext=dict(xref='paper', x=0),
+        titlefont=dict(size=18, family="Oswald, sans-serif"),
+        showline=True,
+        linewidth=2,
+        linecolor="black",
+        showgrid=False,
+    )
+
+    fig.update_yaxes(
+        gridwidth=1,
+        gridcolor="#d7d8d9",
+        tickfont=dict(size=16, family="Oswald, sans-serif"),
+    )
+
     return fig
 
+
 def run_evolution(user_input, config):
-    
-    dfs = run_simulation(user_input['population_params'], user_input['strategy'], config)
-    
-    cols = {'I2': {'name': 'Demanda por leitos', 'color': '#F2C94C', 
-                  'resource_name': 'Capacidade de leitos', 'capacity': user_input['n_beds']}, 
-            'I3': {'name': 'Demanda por ventiladores', 'color': '#0097A7',
-                  'resource_name': 'Capacidade de ventiladores', 'capacity': user_input['n_ventilators']}}
+
+    dfs = run_simulation(
+        user_input["population_params"],
+        user_input["strategy"],
+        config,
+        user_input["place_id"],
+        user_input["place_type"],
+    )
+
+    cols = {
+        "I2": {
+            "name": "Demanda por leitos",
+            "color": "#F2C94C",
+            "resource_name": "Capacidade de leitos",
+            "capacity": user_input["n_beds"],
+        },
+        "I3": {
+            "name": "Demanda por ventiladores",
+            "color": "#0097A7",
+            "resource_name": "Capacidade de ventiladores",
+            "capacity": user_input["n_ventilators"],
+        },
+    }
 
     # Create graph
-    t = dfs['best'][cols.keys()].join(dfs['worst'][cols.keys()], lsuffix='_best', rsuffix='_worst').sort_index(axis=1)    
-    
-    dday_beds = get_dday(dfs,'I2', user_input['n_beds'])   
-    dday_ventilators = get_dday(dfs, 'I3', user_input['n_ventilators'])
-    
+    t = (
+        dfs["best"][cols.keys()]
+        .join(dfs["worst"][cols.keys()], lsuffix="_best", rsuffix="_worst")
+        .sort_index(axis=1)
+    )
+
+    dday_beds = get_dday(dfs, "I2", user_input["n_beds"])
+    dday_ventilators = get_dday(dfs, "I3", user_input["n_ventilators"])
+
     fig = plot_fig(t, cols)
-    
+
     return fig, dday_beds, dday_ventilators
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     pass

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,10 +1,17 @@
 import os
 import sys
-sys.path.insert(0,'./model/')
+
+sys.path.insert(0, "./model/")
 
 import streamlit as st
 from streamlit import caching
-from models import BackgroundColor, Document, Strategies, SimulatorOutput, ResourceAvailability
+from models import (
+    BackgroundColor,
+    Document,
+    Strategies,
+    SimulatorOutput,
+    ResourceAvailability,
+)
 from typing import List
 import utils
 import plotly.express as px
@@ -18,215 +25,311 @@ from pandas import Timestamp
 
 FIXED = datetime.now().minute
 
-def add_all(x, all_string='Todos'):
-        return [all_string] + list(x)
-            
-def filter_options(_df, var, col, all_string='Todos'):
-    if var == 'Todos':
-            return _df
+
+def add_all(x, all_string="Todos"):
+    return [all_string] + list(x)
+
+
+def filter_options(_df, var, col, all_string="Todos"):
+    if var == "Todos":
+        return _df
     else:
-            return _df.query(f'{col} == "{var}"')
-        
+        return _df.query(f'{col} == "{var}"')
+
+
 def choose_place(city, region, state):
-    if city == 'Todos' and region == 'Todos' and state == 'Todos':
-        return 'Brasil'
-    if city == 'Todos' and region == 'Todos':
-        return state + ' (Estado)' if state != 'Todos' else 'Brasil'
-    if city == 'Todos':
-        return region + ' (Região SUS)' if region != 'Todos' else 'Todas as regiões SUS'
+    if city == "Todos" and region == "Todos" and state == "Todos":
+        return "Brasil"
+    if city == "Todos" and region == "Todos":
+        return state + " (Estado)" if state != "Todos" else "Brasil"
+    if city == "Todos":
+        return region + " (Região SUS)" if region != "Todos" else "Todas as regiões SUS"
     return city
 
+
 def refresh_rate(config):
-        dt = (math.floor(datetime.now().minute/config['refresh_rate'])*config['refresh_rate'])
-        return datetime.now().replace(minute=dt,second=0, microsecond=0)
+    dt = (
+        math.floor(datetime.now().minute / config["refresh_rate"])
+        * config["refresh_rate"]
+    )
+    return datetime.now().replace(minute=dt, second=0, microsecond=0)
+
 
 def calculate_recovered(user_input, selected_region, notification_rate):
 
-        confirmed_adjusted = int(selected_region[['confirmed_cases']].sum()/notification_rate)
+    confirmed_adjusted = int(
+        selected_region[["confirmed_cases"]].sum() / notification_rate
+    )
 
-        if confirmed_adjusted == 0: # dont have any cases yet
-                user_input['population_params']['R'] = 0
-                return user_input
-
-        user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['I'] - user_input['population_params']['D']
-
-        if user_input['population_params']['R'] < 0:
-                user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['D']
-        
+    if confirmed_adjusted == 0:  # dont have any cases yet
+        user_input["population_params"]["R"] = 0
         return user_input
 
+    user_input["population_params"]["R"] = (
+        confirmed_adjusted
+        - user_input["population_params"]["I"]
+        - user_input["population_params"]["D"]
+    )
+
+    if user_input["population_params"]["R"] < 0:
+        user_input["population_params"]["R"] = (
+            confirmed_adjusted - user_input["population_params"]["D"]
+        )
+
+    return user_input
+
+
 def main():
-        utils.localCSS("style.css")
-        utils.localCSS("icons.css")
+    utils.localCSS("style.css")
+    utils.localCSS("icons.css")
 
+    # HEADER
+    utils.genHeroSection()
+    utils.genVideoTutorial()
 
-        # HEADER
-        utils.genHeroSection()
-        utils.genVideoTutorial()
+    # GET DATA
+    config = yaml.load(open("configs/config.yaml", "r"), Loader=yaml.FullLoader)
+    cities = loader.read_data(
+        "br", config, endpoint=config["br"]["api"]["endpoints"]["simulacovid"]
+    )
 
+    # REGION/CITY USER INPUT
+    user_input = dict()
 
-        # GET DATA
-        config = yaml.load(open('configs/config.yaml', 'r'), Loader = yaml.FullLoader)
-        cities = loader.read_data('br', config, endpoint=config['br']['api']['endpoints']['simulacovid'])
+    utils.genStateInputSectionHeader()
 
+    user_input["state"] = st.selectbox("Estado", add_all(cities["state_name"].unique()))
+    cities_filtered = filter_options(cities, user_input["state"], "state_name")
 
-        # REGION/CITY USER INPUT
-        user_input = dict()
-        
-        utils.genStateInputSectionHeader()
+    utils.genMunicipalityInputSection()
 
-        user_input['state'] = st.selectbox('Estado', add_all(cities['state_name'].unique()))
-        cities_filtered = filter_options(cities, user_input['state'], 'state_name')
-        
-        utils.genMunicipalityInputSection()
+    user_input["region"] = st.selectbox(
+        "Região SUS", add_all(cities_filtered["health_system_region"].unique())
+    )
+    cities_filtered = filter_options(
+        cities_filtered, user_input["region"], "health_system_region"
+    )
 
-        user_input['region'] = st.selectbox('Região SUS', add_all(cities_filtered['health_system_region'].unique()))
-        cities_filtered = filter_options(cities_filtered, user_input['region'], 'health_system_region')
+    user_input["city"] = st.selectbox(
+        "Município", add_all(cities_filtered["city_name"].unique())
+    )
+    cities_filtered = filter_options(cities_filtered, user_input["city"], "city_name")
 
-        user_input['city'] = st.selectbox('Município', add_all(cities_filtered['city_name'].unique()))
-        cities_filtered = filter_options(cities_filtered, user_input['city'], 'city_name')
+    sources = cities_filtered[
+        [
+            c
+            for c in cities_filtered.columns
+            if (("author" in c) or ("last_updated_" in c))
+        ]
+    ]
 
-        sources = cities_filtered[[c for c in cities_filtered.columns if (('author' in c) or ('last_updated_' in c))]]
- 
-        selected_region = cities_filtered.sum(numeric_only=True)
+    selected_region = cities_filtered.sum(numeric_only=True)
 
+    # GET LAST UPDATE DATE
+    if not np.all(cities_filtered["last_updated"].isna()):
+        last_update_cases = cities_filtered["last_updated"].max().strftime("%d/%m")
 
-        # GET LAST UPDATE DATE
-        if not np.all(cities_filtered['last_updated'].isna()):
-                last_update_cases = cities_filtered['last_updated'].max().strftime('%d/%m')
+    # GET NOTIFICATION RATE
+    if len(cities_filtered) > 1:  # pega taxa do estado quando +1 municipio selecionado
+        notification_rate = round(cities_filtered["state_notification_rate"].mean(), 4)
+        user_input["place_id"] = cities_filtered["state"].iloc[0]
+        user_input["place_type"] = "state"
 
+    elif np.isnan(cities_filtered["notification_rate"].values):
+        notification_rate = 1
+        user_input["place_id"] = cities_filtered["city_id"].iloc[0]
+        user_input["place_type"] = "city_id"
 
-        # GET NOTIFICATION RATE
-        if len(cities_filtered) > 1: # pega taxa do estado quando +1 municipio selecionado
-                notification_rate = round(cities_filtered['state_notification_rate'].mean(), 4)
+    else:
+        notification_rate = round(cities_filtered["notification_rate"].values[0], 4)
+        user_input["place_id"] = cities_filtered["city_id"].iloc[0]
+        user_input["place_type"] = "city_id"
 
-        elif np.isnan(cities_filtered['notification_rate'].values):
-                notification_rate = 1
-        else:
-                notification_rate = round(cities_filtered['notification_rate'].values[0], 4)
+    # pick locality according to hierarchy
+    locality = choose_place(
+        user_input["city"], user_input["region"], user_input["state"]
+    )
 
-        # pick locality according to hierarchy
-        locality = choose_place(user_input['city'], user_input['region'], user_input['state'])
+    st.write("<br/>", unsafe_allow_html=True)
 
-        st.write('<br/>', unsafe_allow_html=True)
+    utils.genInputCustomizationSectionHeader(locality)
 
-        utils.genInputCustomizationSectionHeader(locality)
+    # SOURCES USER INPUT
+    source_beds = sources[
+        ["author_number_beds", "last_updated_number_beds"]
+    ].drop_duplicates()
+    authors_beds = source_beds.author_number_beds.str.cat(sep=", ")
 
+    source_ventilators = sources[
+        ["author_number_ventilators", "last_updated_number_ventilators"]
+    ].drop_duplicates()
+    authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=", ")
 
-        # SOURCES USER INPUT
-        source_beds = sources[['author_number_beds', 'last_updated_number_beds']].drop_duplicates()
-        authors_beds = source_beds.author_number_beds.str.cat(sep=', ')
+    if locality == "Brasil":
+        authors_beds = "SUS e Embaixadores"
+        authors_ventilators = "SUS e Embaixadores"
+        user_input["place_id"] = locality
 
-        source_ventilators = sources[['author_number_ventilators', 'last_updated_number_ventilators']].drop_duplicates()
-        authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=', ')
+    user_input["n_beds"] = st.number_input(
+        f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})",
+        0,
+        None,
+        int(selected_region["number_beds"]),
+    )
 
-        if locality == 'Brasil':
-                authors_beds = 'SUS e Embaixadores'
-                authors_ventilators = 'SUS e Embaixadores'
+    user_input["n_ventilators"] = st.number_input(
+        f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):",
+        0,
+        None,
+        int(selected_region["number_ventilators"]),
+    )
 
-        user_input['n_beds'] = st.number_input(
-                f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})"
-                , 0, None,  int(selected_region['number_beds']))
+    # POP USER INPUTS
+    user_input["population_params"] = {"N": int(selected_region["population"])}
+    user_input["population_params"]["D"] = st.number_input(
+        "Mortes confirmadas:", 0, None, int(selected_region["deaths"])
+    )
 
-        user_input['n_ventilators'] = st.number_input(
-                f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):"
-                , 0, None, int(selected_region['number_ventilators']))
+    # get infected cases
+    infectious_period = (
+        config["br"]["seir_parameters"]["severe_duration"]
+        + config["br"]["seir_parameters"]["critical_duration"]
+    )
 
-
-        # POP USER INPUTS
-        user_input['population_params'] = {'N': int(selected_region['population'])}
-        user_input['population_params']['D'] = st.number_input('Mortes confirmadas:', 0, None, int(selected_region['deaths']))
-        
-        # get infected cases
-        infectious_period = config['br']['seir_parameters']['severe_duration'] + config['br']['seir_parameters']['critical_duration']
-        
-        if selected_region['confirmed_cases'] == 0:
-                st.write(f'''<div class="base-wrapper">
+    if selected_region["confirmed_cases"] == 0:
+        st.write(
+            f"""<div class="base-wrapper">
                 Seu município ou regional de saúde ainda não possui casos reportados oficialmente. Portanto, simulamos como se o primeiro caso ocorresse hoje.
                 <br><br>Caso queria, você pode mudar esse número abaixo:
-                        </div>''', unsafe_allow_html=True)
+                        </div>""",
+            unsafe_allow_html=True,
+        )
 
-                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, 1)
+        user_input["population_params"]["I"] = st.number_input(
+            "Casos ativos estimados:", 0, None, 1
+        )
 
-        else:
-                user_input['population_params']['I'] = int(selected_region['infectious_period_cases'] / notification_rate)
+    else:
+        user_input["population_params"]["I"] = int(
+            selected_region["infectious_period_cases"] / notification_rate
+        )
 
-                st.write(f'''<div class="base-wrapper">
+        st.write(
+            f"""<div class="base-wrapper">
                 O número de casos confirmados oficialmente no seu município ou regional de saúde é de {int(selected_region['confirmed_cases'].sum())} em {last_update_cases}. 
                 Dada a progressão clínica da doença (em média, {infectious_period} dias) e a taxa de notificação ajustada para a região ({int(100*notification_rate)}%), 
                 <b>estimamos que o número de casos ativos é de {user_input['population_params']['I']}</b>.
                 <br><br>Caso queria, você pode mudar esse número para a simulação abaixo:
-                        </div>''', unsafe_allow_html=True)
+                        </div>""",
+            unsafe_allow_html=True,
+        )
 
-                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, user_input['population_params']['I'])
-        
-        # calculate recovered cases
-        user_input = calculate_recovered(user_input, selected_region, notification_rate)
-        
-        # AMBASSADOR SECTION
-        utils.genAmbassadorSection()
-        st.write('<br/>', unsafe_allow_html=True)
+        user_input["population_params"]["I"] = st.number_input(
+            "Casos ativos estimados:", 0, None, user_input["population_params"]["I"]
+        )
 
-        # DEFAULT WORST SCENARIO  
-        user_input['strategy'] = {'isolation': 90, 'lockdown': 90}
-        user_input['population_params']['I'] = [user_input['population_params']['I'] if user_input['population_params']['I'] != 0 else 1][0]
-        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-        
-        worst_case = SimulatorOutput(color=BackgroundColor.GREY_GRADIENT,
-                        min_range_beds=dday_beds['worst'], 
-                        max_range_beds=dday_beds['best'], 
-                        min_range_ventilators=dday_ventilators['worst'],
-                        max_range_ventilators=dday_ventilators['best'])
-        
-        # DEFAULT BEST SCENARIO
-        user_input['strategy'] = {'isolation': 0, 'lockdown': 90}
-        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-        
-        best_case = SimulatorOutput(color=BackgroundColor.LIGHT_BLUE_GRADIENT,
-                        min_range_beds=dday_beds['worst'], 
-                        max_range_beds=dday_beds['best'], 
-                        min_range_ventilators=dday_ventilators['worst'],
-                        max_range_ventilators=dday_ventilators['best'])
+    # calculate recovered cases
+    user_input = calculate_recovered(user_input, selected_region, notification_rate)
 
-        resources = ResourceAvailability(locality=locality, 
-                                        cases=selected_region['active_cases'],
-                                        deaths=selected_region['deaths'], 
-                                        beds=user_input['n_beds'], 
-                                        ventilators=user_input['n_ventilators'])
-        
-        utils.genSimulationSection(int(user_input['population_params']['I']), locality, resources, worst_case, best_case)
-        
-        utils.genActNowSection(locality, worst_case)
-        utils.genStrategiesSection(Strategies)
+    # AMBASSADOR SECTION
+    utils.genAmbassadorSection()
+    st.write("<br/>", unsafe_allow_html=True)
 
+    # DEFAULT WORST SCENARIO
+    user_input["strategy"] = {"isolation": 90, "lockdown": 90}
+    user_input["population_params"]["I"] = [
+        user_input["population_params"]["I"]
+        if user_input["population_params"]["I"] != 0
+        else 1
+    ][0]
+    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
 
-        st.write('''
+    worst_case = SimulatorOutput(
+        color=BackgroundColor.GREY_GRADIENT,
+        min_range_beds=dday_beds["worst"],
+        max_range_beds=dday_beds["best"],
+        min_range_ventilators=dday_ventilators["worst"],
+        max_range_ventilators=dday_ventilators["best"],
+    )
+
+    # DEFAULT BEST SCENARIO
+    user_input["strategy"] = {"isolation": 0, "lockdown": 90}
+    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+
+    best_case = SimulatorOutput(
+        color=BackgroundColor.LIGHT_BLUE_GRADIENT,
+        min_range_beds=dday_beds["worst"],
+        max_range_beds=dday_beds["best"],
+        min_range_ventilators=dday_ventilators["worst"],
+        max_range_ventilators=dday_ventilators["best"],
+    )
+
+    resources = ResourceAvailability(
+        locality=locality,
+        cases=selected_region["active_cases"],
+        deaths=selected_region["deaths"],
+        beds=user_input["n_beds"],
+        ventilators=user_input["n_ventilators"],
+    )
+
+    utils.genSimulationSection(
+        int(user_input["population_params"]["I"]),
+        locality,
+        resources,
+        worst_case,
+        best_case,
+    )
+
+    utils.genActNowSection(locality, worst_case)
+    utils.genStrategiesSection(Strategies)
+
+    st.write(
+        """
         <div class="base-wrapper">
                 <span class="section-header primary-span">Etapa 4: Simule o resultado de possíveis intervenções</span>
                 <br />
                 <span>Agora é a hora de planejar como você pode melhor se preparar para evitar a sobrecarga hospitalar. Veja como mudanças na estratégia adotada afetam a necessidade de internação em leitos.</span>
-        </div>''', unsafe_allow_html=True)
+        </div>""",
+        unsafe_allow_html=True,
+    )
 
-        user_input['strategy']['isolation'] = st.slider('Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)', 0, 90, 0, key='strategy2')
+    user_input["strategy"]["isolation"] = st.slider(
+        "Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)",
+        0,
+        90,
+        0,
+        key="strategy2",
+    )
 
-        user_input['strategy']['lockdown'] = st.slider('Em quantos dias você quer acionar a Estratégia 3, quarentena?', 0, 90, 90, key='strategy3')
-        
-        st.write('<br/><br/>', unsafe_allow_html=True)
-        
-        # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
-        fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config) 
+    user_input["strategy"]["lockdown"] = st.slider(
+        "Em quantos dias você quer acionar a Estratégia 3, quarentena?",
+        0,
+        90,
+        90,
+        key="strategy3",
+    )
 
-        utils.genChartSimulationSection(user_input['strategy']['isolation'], 
-                                        user_input['strategy']['lockdown'], 
-                                        SimulatorOutput(color=BackgroundColor.SIMULATOR_CARD_BG,
-                                                min_range_beds=dday_beds['worst'], 
-                                                max_range_beds=dday_beds['best'], 
-                                                min_range_ventilators=dday_ventilators['worst'],
-                                                max_range_ventilators=dday_ventilators['best']), 
-                                        fig)
+    st.write("<br/><br/>", unsafe_allow_html=True)
 
-        utils.genWhatsappButton()
-        utils.genFooter()
-        
+    # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
+    fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+
+    utils.genChartSimulationSection(
+        user_input["strategy"]["isolation"],
+        user_input["strategy"]["lockdown"],
+        SimulatorOutput(
+            color=BackgroundColor.SIMULATOR_CARD_BG,
+            min_range_beds=dday_beds["worst"],
+            max_range_beds=dday_beds["best"],
+            min_range_ventilators=dday_ventilators["worst"],
+            max_range_ventilators=dday_ventilators["best"],
+        ),
+        fig,
+    )
+
+    utils.genWhatsappButton()
+    utils.genFooter()
+
+
 if __name__ == "__main__":
     main()

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,17 +1,10 @@
 import os
 import sys
-
-sys.path.insert(0, "./model/")
+sys.path.insert(0,'./model/')
 
 import streamlit as st
 from streamlit import caching
-from models import (
-    BackgroundColor,
-    Document,
-    Strategies,
-    SimulatorOutput,
-    ResourceAvailability,
-)
+from models import BackgroundColor, Document, Strategies, SimulatorOutput, ResourceAvailability
 from typing import List
 import utils
 import plotly.express as px
@@ -25,311 +18,215 @@ from pandas import Timestamp
 
 FIXED = datetime.now().minute
 
-
-def add_all(x, all_string="Todos"):
-    return [all_string] + list(x)
-
-
-def filter_options(_df, var, col, all_string="Todos"):
-    if var == "Todos":
-        return _df
+def add_all(x, all_string='Todos'):
+        return [all_string] + list(x)
+            
+def filter_options(_df, var, col, all_string='Todos'):
+    if var == 'Todos':
+            return _df
     else:
-        return _df.query(f'{col} == "{var}"')
-
-
+            return _df.query(f'{col} == "{var}"')
+        
 def choose_place(city, region, state):
-    if city == "Todos" and region == "Todos" and state == "Todos":
-        return "Brasil"
-    if city == "Todos" and region == "Todos":
-        return state + " (Estado)" if state != "Todos" else "Brasil"
-    if city == "Todos":
-        return region + " (Região SUS)" if region != "Todos" else "Todas as regiões SUS"
+    if city == 'Todos' and region == 'Todos' and state == 'Todos':
+        return 'Brasil'
+    if city == 'Todos' and region == 'Todos':
+        return state + ' (Estado)' if state != 'Todos' else 'Brasil'
+    if city == 'Todos':
+        return region + ' (Região SUS)' if region != 'Todos' else 'Todas as regiões SUS'
     return city
 
-
 def refresh_rate(config):
-    dt = (
-        math.floor(datetime.now().minute / config["refresh_rate"])
-        * config["refresh_rate"]
-    )
-    return datetime.now().replace(minute=dt, second=0, microsecond=0)
-
+        dt = (math.floor(datetime.now().minute/config['refresh_rate'])*config['refresh_rate'])
+        return datetime.now().replace(minute=dt,second=0, microsecond=0)
 
 def calculate_recovered(user_input, selected_region, notification_rate):
 
-    confirmed_adjusted = int(
-        selected_region[["confirmed_cases"]].sum() / notification_rate
-    )
+        confirmed_adjusted = int(selected_region[['confirmed_cases']].sum()/notification_rate)
 
-    if confirmed_adjusted == 0:  # dont have any cases yet
-        user_input["population_params"]["R"] = 0
+        if confirmed_adjusted == 0: # dont have any cases yet
+                user_input['population_params']['R'] = 0
+                return user_input
+
+        user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['I'] - user_input['population_params']['D']
+
+        if user_input['population_params']['R'] < 0:
+                user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['D']
+        
         return user_input
 
-    user_input["population_params"]["R"] = (
-        confirmed_adjusted
-        - user_input["population_params"]["I"]
-        - user_input["population_params"]["D"]
-    )
-
-    if user_input["population_params"]["R"] < 0:
-        user_input["population_params"]["R"] = (
-            confirmed_adjusted - user_input["population_params"]["D"]
-        )
-
-    return user_input
-
-
 def main():
-    utils.localCSS("style.css")
-    utils.localCSS("icons.css")
+        utils.localCSS("style.css")
+        utils.localCSS("icons.css")
 
-    # HEADER
-    utils.genHeroSection()
-    utils.genVideoTutorial()
 
-    # GET DATA
-    config = yaml.load(open("configs/config.yaml", "r"), Loader=yaml.FullLoader)
-    cities = loader.read_data(
-        "br", config, endpoint=config["br"]["api"]["endpoints"]["simulacovid"]
-    )
+        # HEADER
+        utils.genHeroSection()
+        utils.genVideoTutorial()
 
-    # REGION/CITY USER INPUT
-    user_input = dict()
 
-    utils.genStateInputSectionHeader()
+        # GET DATA
+        config = yaml.load(open('configs/config.yaml', 'r'), Loader = yaml.FullLoader)
+        cities = loader.read_data('br', config, endpoint=config['br']['api']['endpoints']['simulacovid'])
 
-    user_input["state"] = st.selectbox("Estado", add_all(cities["state_name"].unique()))
-    cities_filtered = filter_options(cities, user_input["state"], "state_name")
 
-    utils.genMunicipalityInputSection()
+        # REGION/CITY USER INPUT
+        user_input = dict()
+        
+        utils.genStateInputSectionHeader()
 
-    user_input["region"] = st.selectbox(
-        "Região SUS", add_all(cities_filtered["health_system_region"].unique())
-    )
-    cities_filtered = filter_options(
-        cities_filtered, user_input["region"], "health_system_region"
-    )
+        user_input['state'] = st.selectbox('Estado', add_all(cities['state_name'].unique()))
+        cities_filtered = filter_options(cities, user_input['state'], 'state_name')
+        
+        utils.genMunicipalityInputSection()
 
-    user_input["city"] = st.selectbox(
-        "Município", add_all(cities_filtered["city_name"].unique())
-    )
-    cities_filtered = filter_options(cities_filtered, user_input["city"], "city_name")
+        user_input['region'] = st.selectbox('Região SUS', add_all(cities_filtered['health_system_region'].unique()))
+        cities_filtered = filter_options(cities_filtered, user_input['region'], 'health_system_region')
 
-    sources = cities_filtered[
-        [
-            c
-            for c in cities_filtered.columns
-            if (("author" in c) or ("last_updated_" in c))
-        ]
-    ]
+        user_input['city'] = st.selectbox('Município', add_all(cities_filtered['city_name'].unique()))
+        cities_filtered = filter_options(cities_filtered, user_input['city'], 'city_name')
 
-    selected_region = cities_filtered.sum(numeric_only=True)
+        sources = cities_filtered[[c for c in cities_filtered.columns if (('author' in c) or ('last_updated_' in c))]]
+ 
+        selected_region = cities_filtered.sum(numeric_only=True)
 
-    # GET LAST UPDATE DATE
-    if not np.all(cities_filtered["last_updated"].isna()):
-        last_update_cases = cities_filtered["last_updated"].max().strftime("%d/%m")
 
-    # GET NOTIFICATION RATE
-    if len(cities_filtered) > 1:  # pega taxa do estado quando +1 municipio selecionado
-        notification_rate = round(cities_filtered["state_notification_rate"].mean(), 4)
-        user_input["place_id"] = cities_filtered["state"].iloc[0]
-        user_input["place_type"] = "state"
+        # GET LAST UPDATE DATE
+        if not np.all(cities_filtered['last_updated'].isna()):
+                last_update_cases = cities_filtered['last_updated'].max().strftime('%d/%m')
 
-    elif np.isnan(cities_filtered["notification_rate"].values):
-        notification_rate = 1
-        user_input["place_id"] = cities_filtered["city_id"].iloc[0]
-        user_input["place_type"] = "city_id"
 
-    else:
-        notification_rate = round(cities_filtered["notification_rate"].values[0], 4)
-        user_input["place_id"] = cities_filtered["city_id"].iloc[0]
-        user_input["place_type"] = "city_id"
+        # GET NOTIFICATION RATE
+        if len(cities_filtered) > 1: # pega taxa do estado quando +1 municipio selecionado
+                notification_rate = round(cities_filtered['state_notification_rate'].mean(), 4)
 
-    # pick locality according to hierarchy
-    locality = choose_place(
-        user_input["city"], user_input["region"], user_input["state"]
-    )
+        elif np.isnan(cities_filtered['notification_rate'].values):
+                notification_rate = 1
+        else:
+                notification_rate = round(cities_filtered['notification_rate'].values[0], 4)
 
-    st.write("<br/>", unsafe_allow_html=True)
+        # pick locality according to hierarchy
+        locality = choose_place(user_input['city'], user_input['region'], user_input['state'])
 
-    utils.genInputCustomizationSectionHeader(locality)
+        st.write('<br/>', unsafe_allow_html=True)
 
-    # SOURCES USER INPUT
-    source_beds = sources[
-        ["author_number_beds", "last_updated_number_beds"]
-    ].drop_duplicates()
-    authors_beds = source_beds.author_number_beds.str.cat(sep=", ")
+        utils.genInputCustomizationSectionHeader(locality)
 
-    source_ventilators = sources[
-        ["author_number_ventilators", "last_updated_number_ventilators"]
-    ].drop_duplicates()
-    authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=", ")
 
-    if locality == "Brasil":
-        authors_beds = "SUS e Embaixadores"
-        authors_ventilators = "SUS e Embaixadores"
-        user_input["place_id"] = locality
+        # SOURCES USER INPUT
+        source_beds = sources[['author_number_beds', 'last_updated_number_beds']].drop_duplicates()
+        authors_beds = source_beds.author_number_beds.str.cat(sep=', ')
 
-    user_input["n_beds"] = st.number_input(
-        f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})",
-        0,
-        None,
-        int(selected_region["number_beds"]),
-    )
+        source_ventilators = sources[['author_number_ventilators', 'last_updated_number_ventilators']].drop_duplicates()
+        authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=', ')
 
-    user_input["n_ventilators"] = st.number_input(
-        f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):",
-        0,
-        None,
-        int(selected_region["number_ventilators"]),
-    )
+        if locality == 'Brasil':
+                authors_beds = 'SUS e Embaixadores'
+                authors_ventilators = 'SUS e Embaixadores'
 
-    # POP USER INPUTS
-    user_input["population_params"] = {"N": int(selected_region["population"])}
-    user_input["population_params"]["D"] = st.number_input(
-        "Mortes confirmadas:", 0, None, int(selected_region["deaths"])
-    )
+        user_input['n_beds'] = st.number_input(
+                f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})"
+                , 0, None,  int(selected_region['number_beds']))
 
-    # get infected cases
-    infectious_period = (
-        config["br"]["seir_parameters"]["severe_duration"]
-        + config["br"]["seir_parameters"]["critical_duration"]
-    )
+        user_input['n_ventilators'] = st.number_input(
+                f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):"
+                , 0, None, int(selected_region['number_ventilators']))
 
-    if selected_region["confirmed_cases"] == 0:
-        st.write(
-            f"""<div class="base-wrapper">
+
+        # POP USER INPUTS
+        user_input['population_params'] = {'N': int(selected_region['population'])}
+        user_input['population_params']['D'] = st.number_input('Mortes confirmadas:', 0, None, int(selected_region['deaths']))
+        
+        # get infected cases
+        infectious_period = config['br']['seir_parameters']['severe_duration'] + config['br']['seir_parameters']['critical_duration']
+        
+        if selected_region['confirmed_cases'] == 0:
+                st.write(f'''<div class="base-wrapper">
                 Seu município ou regional de saúde ainda não possui casos reportados oficialmente. Portanto, simulamos como se o primeiro caso ocorresse hoje.
                 <br><br>Caso queria, você pode mudar esse número abaixo:
-                        </div>""",
-            unsafe_allow_html=True,
-        )
+                        </div>''', unsafe_allow_html=True)
 
-        user_input["population_params"]["I"] = st.number_input(
-            "Casos ativos estimados:", 0, None, 1
-        )
+                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, 1)
 
-    else:
-        user_input["population_params"]["I"] = int(
-            selected_region["infectious_period_cases"] / notification_rate
-        )
+        else:
+                user_input['population_params']['I'] = int(selected_region['infectious_period_cases'] / notification_rate)
 
-        st.write(
-            f"""<div class="base-wrapper">
+                st.write(f'''<div class="base-wrapper">
                 O número de casos confirmados oficialmente no seu município ou regional de saúde é de {int(selected_region['confirmed_cases'].sum())} em {last_update_cases}. 
                 Dada a progressão clínica da doença (em média, {infectious_period} dias) e a taxa de notificação ajustada para a região ({int(100*notification_rate)}%), 
                 <b>estimamos que o número de casos ativos é de {user_input['population_params']['I']}</b>.
                 <br><br>Caso queria, você pode mudar esse número para a simulação abaixo:
-                        </div>""",
-            unsafe_allow_html=True,
-        )
+                        </div>''', unsafe_allow_html=True)
 
-        user_input["population_params"]["I"] = st.number_input(
-            "Casos ativos estimados:", 0, None, user_input["population_params"]["I"]
-        )
+                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, user_input['population_params']['I'])
+        
+        # calculate recovered cases
+        user_input = calculate_recovered(user_input, selected_region, notification_rate)
+        
+        # AMBASSADOR SECTION
+        utils.genAmbassadorSection()
+        st.write('<br/>', unsafe_allow_html=True)
 
-    # calculate recovered cases
-    user_input = calculate_recovered(user_input, selected_region, notification_rate)
+        # DEFAULT WORST SCENARIO  
+        user_input['strategy'] = {'isolation': 90, 'lockdown': 90}
+        user_input['population_params']['I'] = [user_input['population_params']['I'] if user_input['population_params']['I'] != 0 else 1][0]
+        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+        
+        worst_case = SimulatorOutput(color=BackgroundColor.GREY_GRADIENT,
+                        min_range_beds=dday_beds['worst'], 
+                        max_range_beds=dday_beds['best'], 
+                        min_range_ventilators=dday_ventilators['worst'],
+                        max_range_ventilators=dday_ventilators['best'])
+        
+        # DEFAULT BEST SCENARIO
+        user_input['strategy'] = {'isolation': 0, 'lockdown': 90}
+        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+        
+        best_case = SimulatorOutput(color=BackgroundColor.LIGHT_BLUE_GRADIENT,
+                        min_range_beds=dday_beds['worst'], 
+                        max_range_beds=dday_beds['best'], 
+                        min_range_ventilators=dday_ventilators['worst'],
+                        max_range_ventilators=dday_ventilators['best'])
 
-    # AMBASSADOR SECTION
-    utils.genAmbassadorSection()
-    st.write("<br/>", unsafe_allow_html=True)
+        resources = ResourceAvailability(locality=locality, 
+                                        cases=selected_region['active_cases'],
+                                        deaths=selected_region['deaths'], 
+                                        beds=user_input['n_beds'], 
+                                        ventilators=user_input['n_ventilators'])
+        
+        utils.genSimulationSection(int(user_input['population_params']['I']), locality, resources, worst_case, best_case)
+        
+        utils.genActNowSection(locality, worst_case)
+        utils.genStrategiesSection(Strategies)
 
-    # DEFAULT WORST SCENARIO
-    user_input["strategy"] = {"isolation": 90, "lockdown": 90}
-    user_input["population_params"]["I"] = [
-        user_input["population_params"]["I"]
-        if user_input["population_params"]["I"] != 0
-        else 1
-    ][0]
-    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
 
-    worst_case = SimulatorOutput(
-        color=BackgroundColor.GREY_GRADIENT,
-        min_range_beds=dday_beds["worst"],
-        max_range_beds=dday_beds["best"],
-        min_range_ventilators=dday_ventilators["worst"],
-        max_range_ventilators=dday_ventilators["best"],
-    )
-
-    # DEFAULT BEST SCENARIO
-    user_input["strategy"] = {"isolation": 0, "lockdown": 90}
-    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-
-    best_case = SimulatorOutput(
-        color=BackgroundColor.LIGHT_BLUE_GRADIENT,
-        min_range_beds=dday_beds["worst"],
-        max_range_beds=dday_beds["best"],
-        min_range_ventilators=dday_ventilators["worst"],
-        max_range_ventilators=dday_ventilators["best"],
-    )
-
-    resources = ResourceAvailability(
-        locality=locality,
-        cases=selected_region["active_cases"],
-        deaths=selected_region["deaths"],
-        beds=user_input["n_beds"],
-        ventilators=user_input["n_ventilators"],
-    )
-
-    utils.genSimulationSection(
-        int(user_input["population_params"]["I"]),
-        locality,
-        resources,
-        worst_case,
-        best_case,
-    )
-
-    utils.genActNowSection(locality, worst_case)
-    utils.genStrategiesSection(Strategies)
-
-    st.write(
-        """
+        st.write('''
         <div class="base-wrapper">
                 <span class="section-header primary-span">Etapa 4: Simule o resultado de possíveis intervenções</span>
                 <br />
                 <span>Agora é a hora de planejar como você pode melhor se preparar para evitar a sobrecarga hospitalar. Veja como mudanças na estratégia adotada afetam a necessidade de internação em leitos.</span>
-        </div>""",
-        unsafe_allow_html=True,
-    )
+        </div>''', unsafe_allow_html=True)
 
-    user_input["strategy"]["isolation"] = st.slider(
-        "Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)",
-        0,
-        90,
-        0,
-        key="strategy2",
-    )
+        user_input['strategy']['isolation'] = st.slider('Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)', 0, 90, 0, key='strategy2')
 
-    user_input["strategy"]["lockdown"] = st.slider(
-        "Em quantos dias você quer acionar a Estratégia 3, quarentena?",
-        0,
-        90,
-        90,
-        key="strategy3",
-    )
+        user_input['strategy']['lockdown'] = st.slider('Em quantos dias você quer acionar a Estratégia 3, quarentena?', 0, 90, 90, key='strategy3')
+        
+        st.write('<br/><br/>', unsafe_allow_html=True)
+        
+        # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
+        fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config) 
 
-    st.write("<br/><br/>", unsafe_allow_html=True)
+        utils.genChartSimulationSection(user_input['strategy']['isolation'], 
+                                        user_input['strategy']['lockdown'], 
+                                        SimulatorOutput(color=BackgroundColor.SIMULATOR_CARD_BG,
+                                                min_range_beds=dday_beds['worst'], 
+                                                max_range_beds=dday_beds['best'], 
+                                                min_range_ventilators=dday_ventilators['worst'],
+                                                max_range_ventilators=dday_ventilators['best']), 
+                                        fig)
 
-    # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
-    fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-
-    utils.genChartSimulationSection(
-        user_input["strategy"]["isolation"],
-        user_input["strategy"]["lockdown"],
-        SimulatorOutput(
-            color=BackgroundColor.SIMULATOR_CARD_BG,
-            min_range_beds=dday_beds["worst"],
-            max_range_beds=dday_beds["best"],
-            min_range_ventilators=dday_ventilators["worst"],
-            max_range_ventilators=dday_ventilators["best"],
-        ),
-        fig,
-    )
-
-    utils.genWhatsappButton()
-    utils.genFooter()
-
-
+        utils.genWhatsappButton()
+        utils.genFooter()
+        
 if __name__ == "__main__":
     main()

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,10 +1,17 @@
 import os
 import sys
-sys.path.insert(0,'./model/')
+
+sys.path.insert(0, "./model/")
 
 import streamlit as st
 from streamlit import caching
-from models import BackgroundColor, Document, Strategies, SimulatorOutput, ResourceAvailability
+from models import (
+    BackgroundColor,
+    Document,
+    Strategies,
+    SimulatorOutput,
+    ResourceAvailability,
+)
 from typing import List
 import utils
 import plotly.express as px
@@ -18,215 +25,316 @@ from pandas import Timestamp
 
 FIXED = datetime.now().minute
 
-def add_all(x, all_string='Todos'):
-        return [all_string] + list(x)
-            
-def filter_options(_df, var, col, all_string='Todos'):
-    if var == 'Todos':
-            return _df
+
+def add_all(x, all_string="Todos"):
+    return [all_string] + list(x)
+
+
+def filter_options(_df, var, col, all_string="Todos"):
+    if var == "Todos":
+        return _df
     else:
-            return _df.query(f'{col} == "{var}"')
-        
+        return _df.query(f'{col} == "{var}"')
+
+
 def choose_place(city, region, state):
-    if city == 'Todos' and region == 'Todos' and state == 'Todos':
-        return 'Brasil'
-    if city == 'Todos' and region == 'Todos':
-        return state + ' (Estado)' if state != 'Todos' else 'Brasil'
-    if city == 'Todos':
-        return region + ' (Região SUS)' if region != 'Todos' else 'Todas as regiões SUS'
+    if city == "Todos" and region == "Todos" and state == "Todos":
+        return "Brasil"
+    if city == "Todos" and region == "Todos":
+        return state + " (Estado)" if state != "Todos" else "Brasil"
+    if city == "Todos":
+        return region + " (Região SUS)" if region != "Todos" else "Todas as regiões SUS"
     return city
 
+
 def refresh_rate(config):
-        dt = (math.floor(datetime.now().minute/config['refresh_rate'])*config['refresh_rate'])
-        return datetime.now().replace(minute=dt,second=0, microsecond=0)
+    dt = (
+        math.floor(datetime.now().minute / config["refresh_rate"])
+        * config["refresh_rate"]
+    )
+    return datetime.now().replace(minute=dt, second=0, microsecond=0)
+
 
 def calculate_recovered(user_input, selected_region, notification_rate):
 
-        confirmed_adjusted = int(selected_region[['confirmed_cases']].sum()/notification_rate)
+    confirmed_adjusted = int(
+        selected_region[["confirmed_cases"]].sum() / notification_rate
+    )
 
-        if confirmed_adjusted == 0: # dont have any cases yet
-                user_input['population_params']['R'] = 0
-                return user_input
-
-        user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['I'] - user_input['population_params']['D']
-
-        if user_input['population_params']['R'] < 0:
-                user_input['population_params']['R'] = confirmed_adjusted - user_input['population_params']['D']
-        
+    if confirmed_adjusted == 0:  # dont have any cases yet
+        user_input["population_params"]["R"] = 0
         return user_input
 
+    user_input["population_params"]["R"] = (
+        confirmed_adjusted
+        - user_input["population_params"]["I"]
+        - user_input["population_params"]["D"]
+    )
+
+    if user_input["population_params"]["R"] < 0:
+        user_input["population_params"]["R"] = (
+            confirmed_adjusted - user_input["population_params"]["D"]
+        )
+
+    return user_input
+
+
 def main():
-        utils.localCSS("style.css")
-        utils.localCSS("icons.css")
+    utils.localCSS("style.css")
+    utils.localCSS("icons.css")
 
+    # HEADER
+    utils.genHeroSection()
+    utils.genVideoTutorial()
 
-        # HEADER
-        utils.genHeroSection()
-        utils.genVideoTutorial()
+    # GET DATA
+    config = yaml.load(open("configs/config.yaml", "r"), Loader=yaml.FullLoader)
+    cities = loader.read_data(
+        "br", config, endpoint=config["br"]["api"]["endpoints"]["simulacovid"]
+    )
 
+    # REGION/CITY USER INPUT
+    user_input = dict()
 
-        # GET DATA
-        config = yaml.load(open('configs/config.yaml', 'r'), Loader = yaml.FullLoader)
-        cities = loader.read_data('br', config, endpoint=config['br']['api']['endpoints']['simulacovid'])
+    utils.genStateInputSectionHeader()
 
+    user_input["state"] = st.selectbox("Estado", add_all(cities["state_name"].unique()))
+    cities_filtered = filter_options(cities, user_input["state"], "state_name")
 
-        # REGION/CITY USER INPUT
-        user_input = dict()
-        
-        utils.genStateInputSectionHeader()
+    utils.genMunicipalityInputSection()
 
-        user_input['state'] = st.selectbox('Estado', add_all(cities['state_name'].unique()))
-        cities_filtered = filter_options(cities, user_input['state'], 'state_name')
-        
-        utils.genMunicipalityInputSection()
+    user_input["region"] = st.selectbox(
+        "Região SUS", add_all(cities_filtered["health_system_region"].unique())
+    )
+    cities_filtered = filter_options(
+        cities_filtered, user_input["region"], "health_system_region"
+    )
 
-        user_input['region'] = st.selectbox('Região SUS', add_all(cities_filtered['health_system_region'].unique()))
-        cities_filtered = filter_options(cities_filtered, user_input['region'], 'health_system_region')
+    user_input["city"] = st.selectbox(
+        "Município", add_all(cities_filtered["city_name"].unique())
+    )
+    cities_filtered = filter_options(cities_filtered, user_input["city"], "city_name")
 
-        user_input['city'] = st.selectbox('Município', add_all(cities_filtered['city_name'].unique()))
-        cities_filtered = filter_options(cities_filtered, user_input['city'], 'city_name')
+    sources = cities_filtered[
+        [
+            c
+            for c in cities_filtered.columns
+            if (("author" in c) or ("last_updated_" in c))
+        ]
+    ]
 
-        sources = cities_filtered[[c for c in cities_filtered.columns if (('author' in c) or ('last_updated_' in c))]]
- 
-        selected_region = cities_filtered.sum(numeric_only=True)
+    selected_region = cities_filtered.sum(numeric_only=True)
 
+    # GET LAST UPDATE DATE
+    if not np.all(cities_filtered["last_updated"].isna()):
+        last_update_cases = cities_filtered["last_updated"].max().strftime("%d/%m")
 
-        # GET LAST UPDATE DATE
-        if not np.all(cities_filtered['last_updated'].isna()):
-                last_update_cases = cities_filtered['last_updated'].max().strftime('%d/%m')
+    # GET NOTIFICATION RATE
+    if len(cities_filtered) > 1:  # pega taxa do estado quando +1 municipio selecionado
+        notification_rate = round(cities_filtered["state_notification_rate"].mean(), 4)
+        user_input["place_type"] = "state"
 
+    elif np.isnan(cities_filtered["notification_rate"].values):
+        notification_rate = 1
+        user_input["place_type"] = "city_id"
 
-        # GET NOTIFICATION RATE
-        if len(cities_filtered) > 1: # pega taxa do estado quando +1 municipio selecionado
-                notification_rate = round(cities_filtered['state_notification_rate'].mean(), 4)
+    else:
+        notification_rate = round(cities_filtered["notification_rate"].values[0], 4)
+        user_input["place_type"] = "city_id"
 
-        elif np.isnan(cities_filtered['notification_rate'].values):
-                notification_rate = 1
-        else:
-                notification_rate = round(cities_filtered['notification_rate'].values[0], 4)
+    # pick locality according to hierarchy
+    locality = choose_place(
+        user_input["city"], user_input["region"], user_input["state"]
+    )
 
-        # pick locality according to hierarchy
-        locality = choose_place(user_input['city'], user_input['region'], user_input['state'])
+    if user_input["state"] != "Todos":
+        user_input["state"] = cities_filtered["state_id"].values[0]
 
-        st.write('<br/>', unsafe_allow_html=True)
+        if user_input["city"] != "Todos":
+            user_input["city_id"] = cities_filtered["city_id"].values[0]
 
-        utils.genInputCustomizationSectionHeader(locality)
+    st.write("<br/>", unsafe_allow_html=True)
 
+    utils.genInputCustomizationSectionHeader(locality)
 
-        # SOURCES USER INPUT
-        source_beds = sources[['author_number_beds', 'last_updated_number_beds']].drop_duplicates()
-        authors_beds = source_beds.author_number_beds.str.cat(sep=', ')
+    # SOURCES USER INPUT
+    source_beds = sources[
+        ["author_number_beds", "last_updated_number_beds"]
+    ].drop_duplicates()
+    authors_beds = source_beds.author_number_beds.str.cat(sep=", ")
 
-        source_ventilators = sources[['author_number_ventilators', 'last_updated_number_ventilators']].drop_duplicates()
-        authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=', ')
+    source_ventilators = sources[
+        ["author_number_ventilators", "last_updated_number_ventilators"]
+    ].drop_duplicates()
+    authors_ventilators = source_ventilators.author_number_ventilators.str.cat(sep=", ")
 
-        if locality == 'Brasil':
-                authors_beds = 'SUS e Embaixadores'
-                authors_ventilators = 'SUS e Embaixadores'
+    if locality == "Brasil":
+        authors_beds = "SUS e Embaixadores"
+        authors_ventilators = "SUS e Embaixadores"
 
-        user_input['n_beds'] = st.number_input(
-                f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})"
-                , 0, None,  int(selected_region['number_beds']))
+    user_input["n_beds"] = st.number_input(
+        f"Número de leitos destinados aos pacientes com Covid-19 (fonte: {authors_beds}, atualizado: {source_beds.last_updated_number_beds.max().strftime('%d/%m')})",
+        0,
+        None,
+        int(selected_region["number_beds"]),
+    )
 
-        user_input['n_ventilators'] = st.number_input(
-                f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):"
-                , 0, None, int(selected_region['number_ventilators']))
+    user_input["n_ventilators"] = st.number_input(
+        f"Número de ventiladores destinados aos pacientes com Covid-19 (fonte: {authors_ventilators}, atualizado: {source_ventilators.last_updated_number_ventilators.max().strftime('%d/%m')}):",
+        0,
+        None,
+        int(selected_region["number_ventilators"]),
+    )
 
+    # POP USER INPUTS
+    user_input["population_params"] = {"N": int(selected_region["population"])}
+    user_input["population_params"]["D"] = st.number_input(
+        "Mortes confirmadas:", 0, None, int(selected_region["deaths"])
+    )
 
-        # POP USER INPUTS
-        user_input['population_params'] = {'N': int(selected_region['population'])}
-        user_input['population_params']['D'] = st.number_input('Mortes confirmadas:', 0, None, int(selected_region['deaths']))
-        
-        # get infected cases
-        infectious_period = config['br']['seir_parameters']['severe_duration'] + config['br']['seir_parameters']['critical_duration']
-        
-        if selected_region['confirmed_cases'] == 0:
-                st.write(f'''<div class="base-wrapper">
+    # get infected cases
+    infectious_period = (
+        config["br"]["seir_parameters"]["severe_duration"]
+        + config["br"]["seir_parameters"]["critical_duration"]
+    )
+
+    if selected_region["confirmed_cases"] == 0:
+        st.write(
+            f"""<div class="base-wrapper">
                 Seu município ou regional de saúde ainda não possui casos reportados oficialmente. Portanto, simulamos como se o primeiro caso ocorresse hoje.
                 <br><br>Caso queria, você pode mudar esse número abaixo:
-                        </div>''', unsafe_allow_html=True)
+                        </div>""",
+            unsafe_allow_html=True,
+        )
 
-                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, 1)
+        user_input["population_params"]["I"] = st.number_input(
+            "Casos ativos estimados:", 0, None, 1
+        )
 
-        else:
-                user_input['population_params']['I'] = int(selected_region['infectious_period_cases'] / notification_rate)
+    else:
+        user_input["population_params"]["I"] = int(
+            selected_region["infectious_period_cases"] / notification_rate
+        )
 
-                st.write(f'''<div class="base-wrapper">
+        st.write(
+            f"""<div class="base-wrapper">
                 O número de casos confirmados oficialmente no seu município ou regional de saúde é de {int(selected_region['confirmed_cases'].sum())} em {last_update_cases}. 
                 Dada a progressão clínica da doença (em média, {infectious_period} dias) e a taxa de notificação ajustada para a região ({int(100*notification_rate)}%), 
                 <b>estimamos que o número de casos ativos é de {user_input['population_params']['I']}</b>.
                 <br><br>Caso queria, você pode mudar esse número para a simulação abaixo:
-                        </div>''', unsafe_allow_html=True)
+                        </div>""",
+            unsafe_allow_html=True,
+        )
 
-                user_input['population_params']['I'] = st.number_input('Casos ativos estimados:', 0, None, user_input['population_params']['I'])
-        
-        # calculate recovered cases
-        user_input = calculate_recovered(user_input, selected_region, notification_rate)
-        
-        # AMBASSADOR SECTION
-        utils.genAmbassadorSection()
-        st.write('<br/>', unsafe_allow_html=True)
+        user_input["population_params"]["I"] = st.number_input(
+            "Casos ativos estimados:", 0, None, user_input["population_params"]["I"]
+        )
 
-        # DEFAULT WORST SCENARIO  
-        user_input['strategy'] = {'isolation': 90, 'lockdown': 90}
-        user_input['population_params']['I'] = [user_input['population_params']['I'] if user_input['population_params']['I'] != 0 else 1][0]
-        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-        
-        worst_case = SimulatorOutput(color=BackgroundColor.GREY_GRADIENT,
-                        min_range_beds=dday_beds['worst'], 
-                        max_range_beds=dday_beds['best'], 
-                        min_range_ventilators=dday_ventilators['worst'],
-                        max_range_ventilators=dday_ventilators['best'])
-        
-        # DEFAULT BEST SCENARIO
-        user_input['strategy'] = {'isolation': 0, 'lockdown': 90}
-        _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
-        
-        best_case = SimulatorOutput(color=BackgroundColor.LIGHT_BLUE_GRADIENT,
-                        min_range_beds=dday_beds['worst'], 
-                        max_range_beds=dday_beds['best'], 
-                        min_range_ventilators=dday_ventilators['worst'],
-                        max_range_ventilators=dday_ventilators['best'])
+    # calculate recovered cases
+    user_input = calculate_recovered(user_input, selected_region, notification_rate)
 
-        resources = ResourceAvailability(locality=locality, 
-                                        cases=selected_region['active_cases'],
-                                        deaths=selected_region['deaths'], 
-                                        beds=user_input['n_beds'], 
-                                        ventilators=user_input['n_ventilators'])
-        
-        utils.genSimulationSection(int(user_input['population_params']['I']), locality, resources, worst_case, best_case)
-        
-        utils.genActNowSection(locality, worst_case)
-        utils.genStrategiesSection(Strategies)
+    # AMBASSADOR SECTION
+    utils.genAmbassadorSection()
+    st.write("<br/>", unsafe_allow_html=True)
 
+    # DEFAULT WORST SCENARIO
+    user_input["strategy"] = {"isolation": 90, "lockdown": 90}
+    user_input["population_params"]["I"] = [
+        user_input["population_params"]["I"]
+        if user_input["population_params"]["I"] != 0
+        else 1
+    ][0]
 
-        st.write('''
+    # print(user_input)
+
+    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+
+    worst_case = SimulatorOutput(
+        color=BackgroundColor.GREY_GRADIENT,
+        min_range_beds=dday_beds["worst"],
+        max_range_beds=dday_beds["best"],
+        min_range_ventilators=dday_ventilators["worst"],
+        max_range_ventilators=dday_ventilators["best"],
+    )
+
+    # DEFAULT BEST SCENARIO
+    user_input["strategy"] = {"isolation": 0, "lockdown": 90}
+    _, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+
+    best_case = SimulatorOutput(
+        color=BackgroundColor.LIGHT_BLUE_GRADIENT,
+        min_range_beds=dday_beds["worst"],
+        max_range_beds=dday_beds["best"],
+        min_range_ventilators=dday_ventilators["worst"],
+        max_range_ventilators=dday_ventilators["best"],
+    )
+
+    resources = ResourceAvailability(
+        locality=locality,
+        cases=selected_region["active_cases"],
+        deaths=selected_region["deaths"],
+        beds=user_input["n_beds"],
+        ventilators=user_input["n_ventilators"],
+    )
+
+    utils.genSimulationSection(
+        int(user_input["population_params"]["I"]),
+        locality,
+        resources,
+        worst_case,
+        best_case,
+    )
+
+    utils.genActNowSection(locality, worst_case)
+    utils.genStrategiesSection(Strategies)
+
+    st.write(
+        """
         <div class="base-wrapper">
                 <span class="section-header primary-span">Etapa 4: Simule o resultado de possíveis intervenções</span>
                 <br />
                 <span>Agora é a hora de planejar como você pode melhor se preparar para evitar a sobrecarga hospitalar. Veja como mudanças na estratégia adotada afetam a necessidade de internação em leitos.</span>
-        </div>''', unsafe_allow_html=True)
+        </div>""",
+        unsafe_allow_html=True,
+    )
 
-        user_input['strategy']['isolation'] = st.slider('Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)', 0, 90, 0, key='strategy2')
+    user_input["strategy"]["isolation"] = st.slider(
+        "Em quantos dias você quer acionar a Estratégia 2, medidas restritivas? (deixe como 0 se a medida já estiver em vigor)",
+        0,
+        90,
+        0,
+        key="strategy2",
+    )
 
-        user_input['strategy']['lockdown'] = st.slider('Em quantos dias você quer acionar a Estratégia 3, quarentena?', 0, 90, 90, key='strategy3')
-        
-        st.write('<br/><br/>', unsafe_allow_html=True)
-        
-        # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
-        fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config) 
+    user_input["strategy"]["lockdown"] = st.slider(
+        "Em quantos dias você quer acionar a Estratégia 3, quarentena?",
+        0,
+        90,
+        90,
+        key="strategy3",
+    )
 
-        utils.genChartSimulationSection(user_input['strategy']['isolation'], 
-                                        user_input['strategy']['lockdown'], 
-                                        SimulatorOutput(color=BackgroundColor.SIMULATOR_CARD_BG,
-                                                min_range_beds=dday_beds['worst'], 
-                                                max_range_beds=dday_beds['best'], 
-                                                min_range_ventilators=dday_ventilators['worst'],
-                                                max_range_ventilators=dday_ventilators['best']), 
-                                        fig)
+    st.write("<br/><br/>", unsafe_allow_html=True)
 
-        utils.genWhatsappButton()
-        utils.genFooter()
-        
+    # SIMULATOR SCENARIOS: BEDS & RESPIRATORS
+    fig, dday_beds, dday_ventilators = simulator.run_evolution(user_input, config)
+
+    utils.genChartSimulationSection(
+        user_input["strategy"]["isolation"],
+        user_input["strategy"]["lockdown"],
+        SimulatorOutput(
+            color=BackgroundColor.SIMULATOR_CARD_BG,
+            min_range_beds=dday_beds["worst"],
+            max_range_beds=dday_beds["best"],
+            min_range_ventilators=dday_ventilators["worst"],
+            max_range_ventilators=dday_ventilators["best"],
+        ),
+        fig,
+    )
+
+    utils.genWhatsappButton()
+    utils.genFooter()
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Adicionando rt de estados e municípios na simulação:
  - Continuei com os nomes dos parametros de cenarios (`lockdown` = rt/2, `isolation`=rt e `nothing`=rt*2), mas conforme o @gabrielsaruhashi tiver a atualização do front a gente muda as nomeclaturas

 _UPDATES_: 
- Caso o municipio não tenha Rt , usa o Rt do estado
- Caso selecione uma região SUS, usa o Rt do estado

closes #96 